### PR TITLE
Feature/vault save

### DIFF
--- a/Common/Extension/Publisher.swift
+++ b/Common/Extension/Publisher.swift
@@ -12,4 +12,5 @@ extension Publisher {
             }
             .eraseToAnyPublisher()
     }
+    
 }

--- a/Common/Model/FileModel.swift
+++ b/Common/Model/FileModel.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import SwiftUI
 
 class FileModel: ObservableObject, Identifiable {
     

--- a/Common/Model/LoginModel.swift
+++ b/Common/Model/LoginModel.swift
@@ -5,8 +5,21 @@ class LoginModel: ObservableObject, Identifiable {
     @Published var user = ""
     @Published var password = ""
     
-    var dataEntryCompleted: Bool {
-        return !user.isEmpty && !password.isEmpty
+    let loginValueDidChange = PassthroughSubject<Login?, Never>()
+    
+    private var loginValueDidChangeSubscription: AnyCancellable?
+    
+    init() {
+        loginValueDidChangeSubscription = Publishers.CombineLatest($user, $password)
+            .map { user, password in
+                guard !user.isEmpty, !password.isEmpty else {
+                    return nil
+                }
+                return Login(username: user, password: password)
+            }
+            .sink { [loginValueDidChange] login in
+                loginValueDidChange.send(login)
+            }
     }
     
 }

--- a/Common/Model/PasswordModel.swift
+++ b/Common/Model/PasswordModel.swift
@@ -4,8 +4,18 @@ class PasswordModel: ObservableObject, Identifiable {
     
     @Published var password = ""
     
-    var dataEntryCompleted: Bool {
-        return !password.isEmpty
+    let passwordValueDidChange = PassthroughSubject<Password?, Never>()
+    
+    private var passwordValueDidChangeSubscription: AnyCancellable?
+    
+    init() {
+        passwordValueDidChangeSubscription = $password
+            .map { password in
+                return password.isEmpty ? nil : password
+            }
+            .sink { [passwordValueDidChange] password in
+                passwordValueDidChange.send(password)
+            }
     }
     
 }

--- a/Common/Model/SecureItemModel.swift
+++ b/Common/Model/SecureItemModel.swift
@@ -1,0 +1,55 @@
+import Combine
+
+enum SecureItemModel: Identifiable {
+    
+    case login(LoginModel)
+    case password(PasswordModel)
+    case file(FileModel)
+    
+    var id: ObjectIdentifier {
+        switch self {
+        case .login(let model):
+            return model.id
+        case .password(let model):
+            return model.id
+        case .file(let model):
+            return model.id
+        }
+    }
+    
+    var secureItemPublisher: AnyPublisher<SecureItem?, Never> {
+        switch self {
+        case .login(let model):
+            return model.loginValueDidChange
+                .map { login in
+                    guard let login = login else {
+                        return nil
+                    }
+                    
+                    return SecureItem.login(login)
+                }
+                .eraseToAnyPublisher()
+        case .password(let model):
+            return model.passwordValueDidChange
+                .map { password in
+                    guard let password = password else {
+                        return nil
+                    }
+                
+                    return SecureItem.password(password)
+                }
+                .eraseToAnyPublisher()
+        case .file(let model):
+            return model.fileValueDidChange
+                .map { file in
+                    guard let file = file else {
+                        return nil
+                    }
+            
+                    return SecureItem.file(file)
+                }
+                .eraseToAnyPublisher()
+        }
+    }
+    
+}

--- a/Common/Model/SetupModel.swift
+++ b/Common/Model/SetupModel.swift
@@ -15,6 +15,7 @@ class SetupModel: ObservableObject {
             message = nil
         }
     }
+    
     @Published private(set) var isLoading = false
     @Published private(set) var message: Message?
     

--- a/Common/Model/UnlockedModel.swift
+++ b/Common/Model/UnlockedModel.swift
@@ -11,7 +11,7 @@ class UnlockedModel: ObservableObject {
     private let vault: Vault
     
     init(vaultUrl: URL, masterKey: SymmetricKey) {
-        self.vault = Vault(url: vaultUrl, masterKey: masterKey)
+        self.vault = Vault(contentUrl: vaultUrl, masterKey: masterKey)
     }
     
     func createSecureItem(itemType: SecureItemType) {

--- a/Common/Store/Vault.swift
+++ b/Common/Store/Vault.swift
@@ -1,14 +1,36 @@
+import Combine
 import CryptoKit
 import Foundation
 
 class Vault {
     
-    private let url: URL
+    private let contentUrl: URL
     private let masterKey: SymmetricKey
+    private let serialQueue = DispatchQueue(label: "Vault")
     
-    init(url: URL, masterKey: SymmetricKey) {
-        self.url = url
+    init(contentUrl: URL, masterKey: SymmetricKey) {
+        self.contentUrl = contentUrl
         self.masterKey = masterKey
+    }
+    
+    func save(title: String, secureItems: [SecureItem]) -> Future<UUID, Error> {
+        return Future { [contentUrl, masterKey, serialQueue] promise in
+            serialQueue.async {
+                do {
+                    try FileManager.default.createDirectory(at: contentUrl, withIntermediateDirectories: true)
+                    let encodedVaultItem = try SecureContainer.encode(title: title, items: secureItems, using: masterKey)
+                    let secureItemId = UUID()
+                    let secureItemUrl = contentUrl.appendingPathComponent(secureItemId.uuidString, isDirectory: false)
+                    try encodedVaultItem.write(to: secureItemUrl)
+                    
+                    let result = Result<UUID, Error>.success(secureItemId)
+                    promise(result)
+                } catch let error {
+                    let result = Result<UUID, Error>.failure(error)
+                    promise(result)
+                }
+            }
+        }
     }
     
 }

--- a/Common/Value/SecureItem.swift
+++ b/Common/Value/SecureItem.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 enum SecureItem {
     
     case password(Password)

--- a/Vault.xcodeproj/project.pbxproj
+++ b/Vault.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		953EF2DA2444BF1C00627B1B /* VaultItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C42444BF1C00627B1B /* VaultItemView.swift */; };
 		953EF2DC2444BF1C00627B1B /* LockedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C52444BF1C00627B1B /* LockedView.swift */; };
 		953EF2DE2444BF1C00627B1B /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C62444BF1C00627B1B /* ProgressIndicator.swift */; };
-		953EF2E02444BF1C00627B1B /* VaultItemElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C72444BF1C00627B1B /* VaultItemElementView.swift */; };
+		953EF2E02444BF1C00627B1B /* SecureItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C72444BF1C00627B1B /* SecureItemView.swift */; };
 		953EF2E22444BF1C00627B1B /* FileStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C82444BF1C00627B1B /* FileStateView.swift */; };
 		953EF2E42444BF1C00627B1B /* FileStateLoadedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C92444BF1C00627B1B /* FileStateLoadedView.swift */; };
 		953EF2E62444BF1C00627B1B /* FileStateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2CA2444BF1C00627B1B /* FileStateEmptyView.swift */; };
@@ -88,7 +88,7 @@
 		953EF3012444BF8F00627B1B /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C62444BF1C00627B1B /* ProgressIndicator.swift */; };
 		953EF3022444BF8F00627B1B /* SetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2CD2444BF1C00627B1B /* SetupView.swift */; };
 		953EF3032444BF8F00627B1B /* UnlockedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C32444BF1C00627B1B /* UnlockedView.swift */; };
-		953EF3042444BF8F00627B1B /* VaultItemElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C72444BF1C00627B1B /* VaultItemElementView.swift */; };
+		953EF3042444BF8F00627B1B /* SecureItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C72444BF1C00627B1B /* SecureItemView.swift */; };
 		953EF3052444BF8F00627B1B /* VaultItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953EF2C42444BF1C00627B1B /* VaultItemView.swift */; };
 		954FA4F42369D59F005BB821 /* RNGStubTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954FA4F32369D59F005BB821 /* RNGStubTestCase.swift */; };
 		9561123F2437D45D00028F6E /* DecodeMasterKeyPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9561123E2437D45D00028F6E /* DecodeMasterKeyPublisher.swift */; };
@@ -122,6 +122,8 @@
 		956112632438DBED00028F6E /* MasterKeyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A237E23F44F6700142C38 /* MasterKeyContainer.swift */; };
 		95791A6623B61CE20096DC79 /* CryptoWrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 957D62F3238815D7000577FE /* CryptoWrapper.c */; };
 		957D62F62388221C000577FE /* CryptoWrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 957D62F3238815D7000577FE /* CryptoWrapper.c */; };
+		95A0A37E2448707D00815F9B /* SecureItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A550A524486F0700F061AB /* SecureItemModel.swift */; };
+		95A550A624486F0700F061AB /* SecureItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A550A524486F0700F061AB /* SecureItemModel.swift */; };
 		95ACF7CA236F00B100128702 /* SymmetricKeyUnwrapMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ACF7C9236F00B100128702 /* SymmetricKeyUnwrapMock.swift */; };
 		95B20B4623BA1840005D71CD /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B20B4523BA1840005D71CD /* KeyDerivation.swift */; };
 		95B20B4723BA1840005D71CD /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B20B4523BA1840005D71CD /* KeyDerivation.swift */; };
@@ -201,7 +203,7 @@
 		953EF2C42444BF1C00627B1B /* VaultItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VaultItemView.swift; sourceTree = "<group>"; };
 		953EF2C52444BF1C00627B1B /* LockedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockedView.swift; sourceTree = "<group>"; };
 		953EF2C62444BF1C00627B1B /* ProgressIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
-		953EF2C72444BF1C00627B1B /* VaultItemElementView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VaultItemElementView.swift; sourceTree = "<group>"; };
+		953EF2C72444BF1C00627B1B /* SecureItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureItemView.swift; sourceTree = "<group>"; };
 		953EF2C82444BF1C00627B1B /* FileStateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileStateView.swift; sourceTree = "<group>"; };
 		953EF2C92444BF1C00627B1B /* FileStateLoadedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileStateLoadedView.swift; sourceTree = "<group>"; };
 		953EF2CA2444BF1C00627B1B /* FileStateEmptyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileStateEmptyView.swift; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 		9573BFB72365A8A0002BA8C5 /* Test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Test.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		957D62F2238815D7000577FE /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		957D62F3238815D7000577FE /* CryptoWrapper.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CryptoWrapper.c; sourceTree = "<group>"; };
+		95A550A524486F0700F061AB /* SecureItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureItemModel.swift; sourceTree = "<group>"; };
 		95ABF6E72360D39500CA6429 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		95ACF7C9236F00B100128702 /* SymmetricKeyUnwrapMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymmetricKeyUnwrapMock.swift; sourceTree = "<group>"; };
 		95B20B4523BA1840005D71CD /* KeyDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDerivation.swift; sourceTree = "<group>"; };
@@ -310,6 +313,7 @@
 				953EF2972444BDF100627B1B /* FileStateCopyingModel.swift */,
 				953EF2962444BDF100627B1B /* FileStateEmptyModel.swift */,
 				953EF2992444BDF100627B1B /* FileStateLoadedModel.swift */,
+				95A550A524486F0700F061AB /* SecureItemModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -332,7 +336,7 @@
 				953EF2C62444BF1C00627B1B /* ProgressIndicator.swift */,
 				953EF2CD2444BF1C00627B1B /* SetupView.swift */,
 				953EF2C32444BF1C00627B1B /* UnlockedView.swift */,
-				953EF2C72444BF1C00627B1B /* VaultItemElementView.swift */,
+				953EF2C72444BF1C00627B1B /* SecureItemView.swift */,
 				953EF2C42444BF1C00627B1B /* VaultItemView.swift */,
 			);
 			path = View;
@@ -651,6 +655,7 @@
 				953EF3022444BF8F00627B1B /* SetupView.swift in Sources */,
 				956112552438DBDE00028F6E /* PasswordCoding.swift in Sources */,
 				953EF2FE2444BF8F00627B1B /* LoginView.swift in Sources */,
+				95A0A37E2448707D00815F9B /* SecureItemModel.swift in Sources */,
 				956112582438DBDE00028F6E /* UnsignedInteger32BitCoding.swift in Sources */,
 				953EF2FD2444BF8F00627B1B /* LockedView.swift in Sources */,
 				956112532438DBDE00028F6E /* FileCoding.swift in Sources */,
@@ -688,7 +693,7 @@
 				95C12DBF2365B9D200460726 /* Salt.swift in Sources */,
 				953EF2B22444BED800627B1B /* VaultItemModel.swift in Sources */,
 				953EF2FB2444BF8F00627B1B /* FileView.swift in Sources */,
-				953EF3042444BF8F00627B1B /* VaultItemElementView.swift in Sources */,
+				953EF3042444BF8F00627B1B /* SecureItemView.swift in Sources */,
 				953EF3012444BF8F00627B1B /* ProgressIndicator.swift in Sources */,
 				953EF2FC2444BF8F00627B1B /* ListItem.swift in Sources */,
 				95C12DBD2365B9C900460726 /* SaltTestCase.swift in Sources */,
@@ -720,7 +725,7 @@
 				95D29368240826FE00FDD6F4 /* LoginCoding.swift in Sources */,
 				953EF2D22444BF1C00627B1B /* FileStateCopyingView.swift in Sources */,
 				95F5193D23F1601100C5ECA9 /* SecureDataByteBuffer.swift in Sources */,
-				953EF2E02444BF1C00627B1B /* VaultItemElementView.swift in Sources */,
+				953EF2E02444BF1C00627B1B /* SecureItemView.swift in Sources */,
 				953EF29A2444BDF100627B1B /* FileStateEmptyModel.swift in Sources */,
 				953EF2EC2444BF1C00627B1B /* SetupView.swift in Sources */,
 				953EF2882444BB5B00627B1B /* Comparable.swift in Sources */,
@@ -743,6 +748,7 @@
 				957D62F62388221C000577FE /* CryptoWrapper.c in Sources */,
 				953EF2DC2444BF1C00627B1B /* LockedView.swift in Sources */,
 				953EF28F2444BC1800627B1B /* SecureItemType.swift in Sources */,
+				95A550A624486F0700F061AB /* SecureItemModel.swift in Sources */,
 				951C33A724367A64002AA4CD /* ContentWindowController.swift in Sources */,
 				9561123F2437D45D00028F6E /* DecodeMasterKeyPublisher.swift in Sources */,
 				95D293422408247100FDD6F4 /* Password.swift in Sources */,

--- a/macOS/View/SecureItemView.swift
+++ b/macOS/View/SecureItemView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-struct VaultItemElementView: View {
+struct SecureItemView: View {
     
-    let secureItem: VaultItemModel.SecureItem
+    let secureItemModel: SecureItemModel
     
     var body: some View {
-        switch secureItem {
+        switch secureItemModel {
         case .login(let model):
             return LoginView(model: model).eraseToAnyView()
         case .password(let model):

--- a/macOS/View/VaultItemView.swift
+++ b/macOS/View/VaultItemView.swift
@@ -11,7 +11,7 @@ struct VaultItemView: View {
             Divider()
             
             Form {
-                VaultItemElementView(secureItem: model.secureItem)
+                SecureItemView(secureItemModel: model.secureItemModel)
             }
             
             HStack {
@@ -19,7 +19,7 @@ struct VaultItemView: View {
                 Button(.save, action: model.save)
                     .disabled(!model.saveButtonEnabled)
             }
-        }
+        }.disabled(model.isLoading)
     }
     
 }


### PR DESCRIPTION
- Instead of checking if the child models are filled with data, the child models publish their data when they are finished.

- VaultItemModel.SecureItem is renamed To SecureItemModel and moved to a separate file.

- Save in Vault is implemented.

- User input is disabled while saving.

- VaultItemElementView is renamed to SecureItemView.